### PR TITLE
handle exceptions that require special init args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .direnv
 .cache
 *.egg-info
-__pycache___
+__pycache__
 dist/
 build/
 .tox

--- a/README.md
+++ b/README.md
@@ -199,3 +199,9 @@ def foobar(text):
     python setup.py sdist
     twine upload dist/* -u username
     
+
+## Changelog
+
+#### Pending
+ - Can now handle exceptions that require special init args.  Uses a modified class instead of creating a new exception instance. Thanks to @munro for noticing 
+ the issue and finding the right solution.

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ def foobar(text):
 
 ## Updating package on pypi
 
-    git tag 0.1.3
+    git tag 0.3.0
     git push --tags
     python setup.py bdist_wheel
     python setup.py sdist
@@ -202,6 +202,6 @@ def foobar(text):
 
 ## Changelog
 
-#### Pending
+#### 0.3.0
  - Can now handle exceptions that require special init args.  Uses a modified class instead of creating a new exception instance. Thanks to @munro for noticing 
  the issue and finding the right solution.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-__version__ = '0.2.2'
+__version__ = '0.3.0'
 
 setup(
     name="exception-reports",

--- a/tests/manual_test_uncaught_exceptions.py
+++ b/tests/manual_test_uncaught_exceptions.py
@@ -12,7 +12,14 @@ logger = logging.getLogger(__name__)
 # configure uncaught exceptions to be logged
 sys.excepthook = uncaught_exception_handler
 
+
+class SpecialArgsException(Exception):
+
+    def __init__(self, message, important_var):
+        super().__init__(message)
+
+
 try:
-    raise Exception("<strong>YOLO!!!!</strong>")
+    raise SpecialArgsException("<strong>YOLO!!!!</strong>", 24)
 except Exception:
-    raise Exception('<strong>HELLO</strong>')
+    raise SpecialArgsException('<strong>HELLO</strong>', 34)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -21,6 +21,23 @@ def test_decorator():
     assert 'report:/tmp' in str(e)
 
 
+class SpecialArgsException(Exception):
+
+    def __init__(self, message, important_var):
+        super().__init__(message)
+
+
+def test_decorator_with_args_exception():
+    @exception_report()
+    def foobar(text):
+        raise SpecialArgsException("bad things!!", 34)
+
+    with pytest.raises(SpecialArgsException) as e:
+        foobar('hi')
+
+    assert 'report:/tmp' in str(e)
+
+
 @responses.activate
 def test_s3_decorator():
     storage_backend = S3ErrorStorage(

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -81,8 +81,30 @@ def test_custom_s3_decorator():
         raise SpecialException("bad things!!")
 
     with pytest.raises(SpecialException) as e:
-        foobar('hi')
+        try:
+            foobar('hi')
+        except Exception as e2:
+            assert_expection_spec(e2)
+            raise
 
     assert 'report:https://' in str(e)
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith('https://my_bucket.s3.amazonaws.com/all-exceptions/')
+
+
+def test_exception_spec():
+    with pytest.raises(SpecialException):
+        try:
+            raise SpecialException("bad things!!")
+        except Exception as e:
+            # validate Python object API still works on patched object & patched class
+            assert_expection_spec(e)
+            raise
+
+
+def assert_expection_spec(e):
+    # validate Python object API still works on patched object & patched class
+    assert e.__class__.__name__ == 'SpecialException'
+    assert isinstance(e, SpecialException)
+    assert issubclass(e.__class__, Exception)
+    assert issubclass(e.__class__, SpecialException)


### PR DESCRIPTION
Can now handle exceptions that require special init args.  Uses a modified class instead of creating a new exception instance. Thanks to @munro for noticing the issue and finding the right solution.